### PR TITLE
Use year in date formats, not week year

### DIFF
--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopProcessFactory.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopProcessFactory.java
@@ -44,7 +44,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class AtopProcessFactory
         implements AtopFactory
 {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("YYYYMMdd");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private final String executablePath;
     private final ZoneId timeZone;
     private final Duration readTimeout;

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryIdGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryIdGenerator.java
@@ -43,7 +43,7 @@ public class QueryIdGenerator
         checkState(ImmutableSet.copyOf(Chars.asList(BASE_32)).size() == 32);
     }
 
-    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormat.forPattern("YYYYMMdd_HHmmss").withZoneUTC();
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormat.forPattern("yyyyMMdd_HHmmss").withZoneUTC();
     private static final long BASE_SYSTEM_TIME_MILLIS = System.currentTimeMillis();
     private static final long BASE_NANO_TIME = System.nanoTime();
 

--- a/presto-main/src/main/java/com/facebook/presto/util/CompilerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/CompilerUtils.java
@@ -35,7 +35,7 @@ public final class CompilerUtils
     private static final Logger log = Logger.get(CompilerUtils.class);
 
     private static final AtomicLong CLASS_ID = new AtomicLong();
-    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYYMMdd_HHmmss");
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
 
     private CompilerUtils() {}
 


### PR DESCRIPTION
Week year can cause problems at the beginning/end of the year, when it
can be different from year (e.g. week year of 2017-12-31 is 2018)